### PR TITLE
change port visibility

### DIFF
--- a/core/src/main/java/se/sics/kompics/JavaComponent.java
+++ b/core/src/main/java/se/sics/kompics/JavaComponent.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import se.sics.kompics.Fault.ResolveAction;
@@ -97,6 +98,11 @@ public class JavaComponent extends ComponentCore {
         return positiveControl;
     }
 
+    Map<Class<? extends PortType>, JavaPort<? extends PortType>> getNegativePorts() {
+        return negativePorts;
+    }
+
+
     /*
      * (non-Javadoc)
      *
@@ -116,6 +122,10 @@ public class JavaComponent extends ComponentCore {
     @Override
     public <P extends PortType> Negative<P> required(Class<P> portType) {
         return getNegative(portType);
+    }
+
+    Map<Class<? extends PortType>, JavaPort<? extends PortType>> getPositivePorts() {
+        return positivePorts;
     }
 
     /*

--- a/core/src/main/java/se/sics/kompics/PortType.java
+++ b/core/src/main/java/se/sics/kompics/PortType.java
@@ -165,6 +165,14 @@ public abstract class PortType {
 				: hasNegative(eventType));
 	}
 
+	Set<Class<? extends KompicsEvent>> getPositiveEvents() {
+		return positive;
+	}
+
+	Set<Class<? extends KompicsEvent>> getNegativeEvents() {
+		return negative;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * 

--- a/core/src/main/java/se/sics/kompics/Unsafe.java
+++ b/core/src/main/java/se/sics/kompics/Unsafe.java
@@ -1,0 +1,23 @@
+package se.sics.kompics;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class Unsafe {
+
+  public static Map<Class<? extends PortType>, JavaPort<? extends PortType>> getPositivePorts(Component component) {
+    return ((JavaComponent) component).getPositivePorts();
+  }
+
+  public static Map<Class<? extends PortType>, JavaPort<? extends PortType>> getNegativePorts(Component component) {
+    return ((JavaComponent) component).getNegativePorts();
+  }
+
+  public static Collection<Class<? extends KompicsEvent>> getPositiveEvents(PortType portType) {
+    return portType.getPositiveEvents();
+  }
+
+  public static Collection<Class<? extends KompicsEvent>> getNegativeEvents(PortType portType) {
+    return portType.getNegativeEvents();
+  }
+}

--- a/core/src/main/java/se/sics/kompics/Unsafe.java
+++ b/core/src/main/java/se/sics/kompics/Unsafe.java
@@ -3,21 +3,22 @@ package se.sics.kompics;
 import java.util.Collection;
 import java.util.Map;
 
-public class Unsafe {
+public abstract class Unsafe {
 
   public static Map<Class<? extends PortType>, JavaPort<? extends PortType>> getPositivePorts(Component component) {
-    return ((JavaComponent) component).getPositivePorts();
+      return ((JavaComponent) component).getPositivePorts();
   }
 
   public static Map<Class<? extends PortType>, JavaPort<? extends PortType>> getNegativePorts(Component component) {
-    return ((JavaComponent) component).getNegativePorts();
+      return ((JavaComponent) component).getNegativePorts();
   }
 
   public static Collection<Class<? extends KompicsEvent>> getPositiveEvents(PortType portType) {
-    return portType.getPositiveEvents();
+      return portType.getPositiveEvents();
   }
 
   public static Collection<Class<? extends KompicsEvent>> getNegativeEvents(PortType portType) {
-    return portType.getNegativeEvents();
+      return portType.getNegativeEvents();
   }
 }
+


### PR DESCRIPTION
changes access to provided/required ports for JavaComponent as well as
positive/negative events for a PortType via package-private methods.
Class Unsafe provides public methods to expose them explicitly.