### PR TITLE
reflect Direct.Request via Unsafe

### DIFF
--- a/core/src/main/java/se/sics/kompics/Direct.java
+++ b/core/src/main/java/se/sics/kompics/Direct.java
@@ -13,7 +13,7 @@ public class Direct {
 
     public static class Request<R extends Response> implements KompicsEvent {
 
-        private Port origin;
+        Port origin;
         private R response;
 
         void setOrigin(Port origin) {

--- a/core/src/main/java/se/sics/kompics/Unsafe.java
+++ b/core/src/main/java/se/sics/kompics/Unsafe.java
@@ -6,19 +6,30 @@ import java.util.Map;
 public abstract class Unsafe {
 
   public static Map<Class<? extends PortType>, JavaPort<? extends PortType>> getPositivePorts(Component component) {
-      return ((JavaComponent) component).getPositivePorts();
+       return ((JavaComponent) component).getPositivePorts();
   }
 
   public static Map<Class<? extends PortType>, JavaPort<? extends PortType>> getNegativePorts(Component component) {
-      return ((JavaComponent) component).getNegativePorts();
+       return ((JavaComponent) component).getNegativePorts();
   }
 
   public static Collection<Class<? extends KompicsEvent>> getPositiveEvents(PortType portType) {
-      return portType.getPositiveEvents();
+       return portType.getPositiveEvents();
   }
 
   public static Collection<Class<? extends KompicsEvent>> getNegativeEvents(PortType portType) {
-      return portType.getNegativeEvents();
+       return portType.getNegativeEvents();
+  }
+
+  public static void setOrigin(Direct.Request<? extends Direct.Response> request, Port origin) {
+       request.origin = origin;
+  }
+
+  public static Port getOrigin(Direct.Request<? extends Direct.Response> request) {
+       return request.getOrigin();
+  }
+
+  public static <P extends PortType> JavaPort<P> createJavaPort(boolean positive, P portType, ComponentCore owner) {
+       return new JavaPort<P>(positive, portType, owner);
   }
 }
-


### PR DESCRIPTION
changes visibility of origin in Direct.Request to default and adds
setter/getter methods as well as a factory method for creating JavaPort
instances to Unsafe.