### PR TITLE
config update - parent will be null for root comp

### DIFF
--- a/core/src/main/java/se/sics/kompics/JavaComponent.java
+++ b/core/src/main/java/se/sics/kompics/JavaComponent.java
@@ -567,8 +567,10 @@ public class JavaComponent extends ComponentCore {
                     forwardedEvent, wid, this);
         }
         // forward up
-        ((PortCore<ControlPort>) parent.getControl()).doTrigger(
-                forwardedEvent, wid, this);
+        if (parent != null) {
+          ((PortCore<ControlPort>) parent.getControl()).doTrigger(
+            forwardedEvent, wid, this);
+        }
         component.postUpdate();
     }
 


### PR DESCRIPTION
 The root component doesn't have a parent. Null check for parent in the case of config changes propagation.