### PR TITLE
Bintray dependencies

### DIFF
--- a/basic/component-java-timer/pom.xml
+++ b/basic/component-java-timer/pom.xml
@@ -4,26 +4,26 @@
 	<parent>
 		<groupId>se.sics.kompics.basic</groupId>
 		<artifactId>kompics-basic-components</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<groupId>se.sics.kompics.basic</groupId>
 	<artifactId>kompics-component-java-timer</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<name>JavaTimer Kompics Component</name>
 
 	<dependencies>
 		<dependency>
 			<groupId>se.sics.kompics</groupId>
 			<artifactId>kompics-core</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>se.sics.kompics.basic</groupId>
 			<artifactId>kompics-port-timer</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/basic/component-netty-network/pom.xml
+++ b/basic/component-netty-network/pom.xml
@@ -1,4 +1,3 @@
-
 <!--
 This file is part of the CaracalDB distributed storage system.
 
@@ -30,7 +29,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <artifactId>kompics-component-netty-network</artifactId>
     <packaging>jar</packaging>
     <name>Kompics Netty Network</name>
-
     <dependencies>
         <dependency>
             <groupId>se.sics.kompics.basic</groupId>
@@ -42,7 +40,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
             <version>5.0.0.Alpha3</version>
-            <!-- <version>5.0.0.Alpha3-SNAPSHOT</version> //-->
+            <!-- <version>5.0.0.Alpha3-SNAPSHOT</version>//-->
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -57,11 +55,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
-        <!--<dependency>
-            <groupId>javassist</groupId>
-            <artifactId>javassist</artifactId>
-            <version>3.12.1.GA</version>
-        </dependency>//-->
+        <!--<dependency><groupId>javassist</groupId><artifactId>javassist</artifactId><version>3.12.1.GA</version></dependency>//-->
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
@@ -70,7 +64,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             <optional>true</optional>
         </dependency>
     </dependencies>
-    
     <build>
         <plugins>
             <plugin>
@@ -126,5 +119,24 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         </profile>
     </profiles>
 
-</project>
 
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray-kompics-Maven</id>
+            <name>bintray</name>
+            <url>https://dl.bintray.com/kompics/Maven</url>
+        </repository>
+        <!-- this is where the custom Netty implementation is from //-->
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray-lkrollcom-maven</id>
+            <name>bintray</name>
+            <url>https://dl.bintray.com/lkrollcom/maven</url>
+        </repository>
+    </repositories>
+</project>

--- a/basic/component-netty-network/pom.xml
+++ b/basic/component-netty-network/pom.xml
@@ -121,22 +121,22 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 
     <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-kompics-Maven</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/kompics/Maven</url>
-        </repository>
-        <!-- this is where the custom Netty implementation is from //-->
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-lkrollcom-maven</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/lkrollcom/maven</url>
-        </repository>
-    </repositories>
+    <repository>
+        <snapshots>
+            <enabled>false</enabled>
+        </snapshots>
+        <id>bintray-kompics-Maven</id>
+        <name>bintray</name>
+        <url>https://dl.bintray.com/kompics/Maven</url>
+    </repository>
+    <!-- this is where the custom Netty implementation is from //-->
+    <repository>
+        <snapshots>
+            <enabled>false</enabled>
+        </snapshots>
+        <id>bintray-lkrollcom-maven</id>
+        <name>bintray</name>
+        <url>https://dl.bintray.com/lkrollcom/maven</url>
+    </repository>
+</repositories>
 </project>

--- a/basic/component-netty-network/pom.xml
+++ b/basic/component-netty-network/pom.xml
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <parent>
         <groupId>se.sics.kompics.basic</groupId>
         <artifactId>kompics-basic-components</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <groupId>se.sics.kompics.basic</groupId>
     <artifactId>kompics-component-netty-network</artifactId>
@@ -33,7 +33,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         <dependency>
             <groupId>se.sics.kompics.basic</groupId>
             <artifactId>kompics-port-network</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/basic/data-network-interceptor/pom.xml
+++ b/basic/data-network-interceptor/pom.xml
@@ -1,4 +1,3 @@
-
 <!--
 This file is part of the CaracalDB distributed storage system.
 
@@ -30,7 +29,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <artifactId>kompics-data-network-interceptor</artifactId>
     <packaging>jar</packaging>
     <name>Kompics NetData Interceptor</name>
-
     <dependencies>
         <dependency>
             <groupId>se.sics.kompics.basic</groupId>
@@ -91,7 +89,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             <scope>compile</scope>
         </dependency>
     </dependencies>
-    
     <build>
         <plugins>
             <plugin>
@@ -110,6 +107,23 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
             </plugin>
         </plugins>
     </build>
-
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray-kompics-Maven</id>
+            <name>bintray</name>
+            <url>https://dl.bintray.com/kompics/Maven</url>
+        </repository>
+        <!-- this is where the common-utils is from //-->
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray-lkrollcom-maven</id>
+            <name>bintray</name>
+            <url>https://dl.bintray.com/lkrollcom/maven</url>
+        </repository>
+    </repositories>
 </project>
-

--- a/basic/data-network-interceptor/pom.xml
+++ b/basic/data-network-interceptor/pom.xml
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     <parent>
         <groupId>se.sics.kompics.basic</groupId>
         <artifactId>kompics-basic-components</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <groupId>se.sics.kompics.basic</groupId>
     <artifactId>kompics-data-network-interceptor</artifactId>
@@ -33,13 +33,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         <dependency>
             <groupId>se.sics.kompics.basic</groupId>
             <artifactId>kompics-port-network</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>se.sics.kompics.basic</groupId>
             <artifactId>kompics-port-timer</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -73,13 +73,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         <dependency>
             <groupId>se.sics.kompics.basic</groupId>
             <artifactId>kompics-component-netty-network</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>se.sics.kompics.basic</groupId>
             <artifactId>kompics-component-java-timer</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/basic/data-network-interceptor/pom.xml
+++ b/basic/data-network-interceptor/pom.xml
@@ -59,7 +59,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
         <dependency>
             <groupId>com.larskroll</groupId>
             <artifactId>common-utils</artifactId>
-            <version>1.1</version>
+            <version>1.4.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/basic/pom.xml
+++ b/basic/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>kompics-parent-pom</artifactId>
 		<groupId>se.sics.kompics</groupId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
@@ -11,7 +11,7 @@
 	<artifactId>kompics-basic-components</artifactId>
 	<packaging>pom</packaging>
 	<name>Kompics basic components and ports</name>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<description>Basic components for timers, network communication, and web server</description>
 
 	<modules>

--- a/basic/pom.xml
+++ b/basic/pom.xml
@@ -22,29 +22,4 @@
 		<module>component-netty-network</module>
 		<module>data-network-interceptor</module>
 	</modules>
-
-	<repositories>
-		<repository>
-			<id>sics-release</id>
-			<name>SICS Release Repository</name>
-			<url>http://kompics.sics.se/maven/repository</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>sics-snapshot</id>
-			<name>SICS Snapshot Repository</name>
-			<url>http://kompics.sics.se/maven/snapshotrepository</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
 </project>

--- a/basic/port-network/pom.xml
+++ b/basic/port-network/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>se.sics.kompics.basic</groupId>
         <artifactId>kompics-basic-components</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
 
 	<artifactId>kompics-port-network</artifactId>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>se.sics.kompics</groupId>
             <artifactId>kompics-core</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/basic/port-timer/pom.xml
+++ b/basic/port-timer/pom.xml
@@ -4,20 +4,20 @@
     <parent>
         <groupId>se.sics.kompics.basic</groupId>
         <artifactId>kompics-basic-components</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
 
 	<groupId>se.sics.kompics.basic</groupId>
 	<artifactId>kompics-port-timer</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<name>Kompics Timer PortType</name>
 
     <dependencies>
         <dependency>
             <groupId>se.sics.kompics</groupId>
             <artifactId>kompics-core</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/basic/port-virtual-network/pom.xml
+++ b/basic/port-virtual-network/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>se.sics.kompics.basic</groupId>
         <artifactId>kompics-basic-components</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
 
 	<artifactId>kompics-port-virtual-network</artifactId>
@@ -15,13 +15,13 @@
         <dependency>
             <groupId>se.sics.kompics</groupId>
             <artifactId>kompics-core</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>se.sics.kompics.basic</groupId>
             <artifactId>kompics-port-network</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>se.sics.kompics</groupId>
 		<artifactId>kompics-parent-pom</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<artifactId>kompics-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>se.sics.kompics</groupId>
 	<artifactId>kompics-parent-pom</artifactId>
 	<packaging>pom</packaging>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<!-- Spacer //-->
 	<name>Kompics</name>
 	<url>http://kompics.sics.se</url>

--- a/pom.xml
+++ b/pom.xml
@@ -102,27 +102,29 @@ by putting together protocols programmed as event-driven components.</descriptio
 				</configuration>
 			</plugin>
 			<plugin>
-			    <groupId>org.apache.maven.plugins</groupId>
-			    <artifactId>maven-surefire-plugin</artifactId>
-			    <version>3.0.0-M3</version>
-			    <configuration>
-			        <forkCount>1</forkCount>
-			        <reuseForks>true</reuseForks>
-			        <argLine>-Xmx2024m</argLine>
-			        <forkedProcessExitTimeoutInSeconds>5</forkedProcessExitTimeoutInSeconds>
-			        <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
-			    </configuration>
-		  	</plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M3</version>
+				<configuration>
+					<forkCount>1</forkCount>
+					<reuseForks>true</reuseForks>
+					<argLine>-Xmx2024m</argLine>
+					<forkedProcessExitTimeoutInSeconds>5</forkedProcessExitTimeoutInSeconds>
+					<forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 				<version>3.0.1</version>
 				<executions>
 					<execution>
-	                    <id>attach-sources</id>
-	                    <phase>package</phase>
-	                    <goals><goal>jar-no-fork</goal></goals>
-                	</execution>
+						<id>attach-sources</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
 				</executions>
 			</plugin>
 			<plugin>
@@ -182,11 +184,11 @@ by putting together protocols programmed as event-driven components.</descriptio
 	</build>
 	<!-- Spacer //-->
 	<distributionManagement>
-	    <repository>
-	        <id>bintray-kompics-Maven</id>
-	        <name>kompics-Maven</name>
-	        <url>https://api.bintray.com/maven/kompics/Maven/kompics/;publish=1</url>
-	    </repository>
+		<repository>
+			<id>bintray-kompics-Maven</id>
+			<name>kompics-Maven</name>
+			<url>https://api.bintray.com/maven/kompics/Maven/kompics/;publish=1</url>
+		</repository>
 	</distributionManagement>
 	<!-- Spacer //-->
 	<reporting>


### PR DESCRIPTION
Make sure that no dependencies are pulled from the old repositories anymore.

This includes some dependency version updates, thus the path version bump.